### PR TITLE
making migrations work in redmine3/rails4 by changing order of has_many arguments

### DIFF
--- a/lib/oauth_provider_user_patch.rb
+++ b/lib/oauth_provider_user_patch.rb
@@ -5,7 +5,7 @@ module OauthProviderUserPatch
       unloadable
 
       has_many :client_applications
-      has_many :tokens, {:class_name => "OauthToken"},  ->{includes(:client_application).order("authorized_at desc")}
+      has_many :tokens, -> {includes(:client_application).order("authorized_at desc")}, {:class_name => "OauthToken"}
     end
   end
 end


### PR DESCRIPTION
After upgrading to Redmine3 (Rails 4) I end up with the following error message after trying to run the migrations.

```
$ bundle exec rake redmine:plugins:migrate RAILS_ENV=production
rake aborted!
ArgumentError: wrong number of arguments (1 for 0)
/Users/Shared/www/redmine WB/redmine/plugins/redmine_oauth_provider/lib/oauth_provider_user_patch.rb:8:in `block (2 levels) in included'
```
